### PR TITLE
Added new cog for Nhoặn counting

### DIFF
--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -19,7 +19,8 @@ NAMES = [
     'emotes',
     'games',
 
-    'misc',
+    'nhoancounter',
+    'misc'
 ]
 
 LIST = ['cogs.' + cog for cog in NAMES]

--- a/cogs/__init__.py
+++ b/cogs/__init__.py
@@ -19,7 +19,7 @@ NAMES = [
     'emotes',
     'games',
 
-    'nhoancounter',
+    'nhoan',
     'misc'
 ]
 

--- a/cogs/core/converter/members.py
+++ b/cogs/core/converter/members.py
@@ -5,7 +5,7 @@ import discord
 
 DEFAULT_MATCHING = .4
 
-class FuzzyMember(commands.MemberConverter):
+class FuzzyMemberConverter(commands.MemberConverter):
     def __init__(self, *, matching=DEFAULT_MATCHING):
         self.matching = matching
     
@@ -18,7 +18,7 @@ class FuzzyMember(commands.MemberConverter):
                 return member
             raise
 
-FuzzyMember = typing.Union[discord.Member, FuzzyMember]
+FuzzyMember = typing.Union[discord.Member, FuzzyMemberConverter]
 
 ROLE_SCORE_WEIGHT = 0.025
 MATCH_RETURNS = 10

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -23,7 +23,8 @@ COG_EMOTES = {
     'Snipe': '🕵',
     'Emotes': 'me',
     'Games': '🎲',
-    'Misc': '♾️',
+    'Nhoặn': 'joikhomg',
+    'Misc': '♾️'
 }
 
 COG_FROM_EMOTES = { v: k for k, v in COG_EMOTES.items() }

--- a/cogs/nhoan.py
+++ b/cogs/nhoan.py
@@ -6,20 +6,24 @@ from typing import Optional, Union
 from discord.ext import commands
 from .core import converter as conv
 
+TITLE = 'Nhoặn Counter'
+
 NHOAN_COUNTER = 'nhoan_counter'
 GUILD_NHOAN_SUM_COUNTER = 'guild_nhoan_sums'
+
 NHOANMSG_FIRSTTIME = '{0} just posted nhoặn for the first time!'
 NHOANMSG_UPDATE = '{0} just posted nhoặn, that\'s {1} times now!'
 NHOANMSG_QUERY_0 = '{0} has not posted nhoặn. Yet!'
 NHOANMSG_QUERY_N = '{0} has posted nhoặn {1} time{2}, ranking **{3}** in the server!'
 
-NHOANEMBED_AUTHOR_N = '{0}\'s nhoặn count'
 NHOANEMBED_FOOTER = 'Total server nhoặn moments counted: {0}'
 
 TOPNHOAN_TITLE = 'Khúm núm before your nhoặn leaders!'
 TOPNHOAN_ENTRY = '**{0}**: {1}, with {2} nhoặn post{3}\n'
 
-class Nhoặn(commands.Cog):
+NHOAN_SYNONYMS = ['nhoan', 'nhoặn', 'cringe', 'crimge']
+
+class Nhoan(commands.Cog, name='Nhoặn'):
     def __init__(self, bot):
         self.bot = bot
         self.Persist = bot.get_cog(cogs.PERSIST)
@@ -37,7 +41,7 @@ class Nhoặn(commands.Cog):
         self.Persist.set(GUILD_NHOAN_SUM_COUNTER, self.allguildsnhoan)
 
     def init_embed(self, guild: discord.Guild):
-        embed = colors.embed()
+        embed = colors.embed(title=TITLE)
         embed.set_footer(text = NHOANEMBED_FOOTER.format(self.allguildsnhoan.get(guild, 0)))
         return embed
     
@@ -51,7 +55,21 @@ class Nhoặn(commands.Cog):
         else:
             return enumerate(allnhoan_top, start = 1)
         
-    @commands.command(aliases = ['nhoặn', 'nh'])
+    @commands.Cog.listener()
+    async def on_message(self, msg):
+        ctx = await self.bot.get_context(msg)
+        if ctx.command: return
+
+        for nhoan in NHOAN_SYNONYMS:
+            if nhoan in msg.content.split():
+                possible_name = msg.content.split(nhoan)[0]
+                try:
+                    member = await conv.members.FuzzyMemberConverter(matching=.6).convert(ctx, possible_name)
+                except:
+                    return
+                await self.bump_nhoan_count(ctx, member)
+    
+    @commands.command(aliases = ['nhoặn', 'nh', 'cringe', 'crimge'])
     async def nhoan(self, ctx, member: Optional[conv.FuzzyMember] = None):
         last_msgs = await ctx.channel.history(limit=2).flatten()
         msg_before_invoke = last_msgs[1] if len(last_msgs) > 1 else None
@@ -60,47 +78,54 @@ class Nhoặn(commands.Cog):
         else:
             await ctx.send('No last message found. I don\'t know who to add nhoặn to!')
             return
+        if member == ctx.message.author:
+            await ctx.send('You cannot call nhoặn on yourself!')
+            return
 
+        await self.bump_nhoan_count(ctx, member)
+
+    async def bump_nhoan_count(self, ctx, member):
         m_id = member.id
         original_count = self.allnhoan.get(m_id, 0)
         self.sync_nhoan_count(member, ctx.guild, original_count + 1)
         
         embed = self.init_embed(ctx.guild)
-        embed.set_author(name = NHOANEMBED_AUTHOR_N.format(member.name))
         if original_count == 0:
-            embed.description = NHOANMSG_FIRSTTIME.format(member.name)
+            embed.description = NHOANMSG_FIRSTTIME.format(member.mention)
         else:
-            embed.description = NHOANMSG_UPDATE.format(member.name, \
+            embed.description = NHOANMSG_UPDATE.format(member.mention, \
                 str(original_count + 1))
         await ctx.send(embed = embed)
 
-    @commands.command(aliases = ['hnh','hownh'])
+    @commands.command(aliases = ['hownh', 'nhoancount', 'cringecount', 'crimgecount'])
     async def hownhoan(self, ctx, member: Optional[conv.FuzzyMember] = None):
         member = member or ctx.author
+        nhoantimes = 0
         for rank, (memb, nhoantimes) in self.get_sorted_counts(ctx.guild):
             if memb == member: break
         embed = self.init_embed(ctx.guild)
-        embed.set_author(name = NHOANEMBED_AUTHOR_N.format(member.name))
         if nhoantimes == 0:
-            embed.description = NHOANMSG_QUERY_0.format(member.name)
+            you = 'You ' if member == ctx.author else ''
+            embed.description = you + NHOANMSG_QUERY_0.format(member.mention)
         else:
             # get_ordinal implementation from https://stackoverflow.com/a/36977549
             get_ordinal = lambda n: \
                 "%d%s" % (n, {1: "st", 2: "nd", 3: "rd"}.get(n if n < 20 else n % 10, "th"))
-            embed.description = NHOANMSG_QUERY_N.format(member.name, \
+            embed.description = NHOANMSG_QUERY_N.format(member.mention, \
                 str(nhoantimes), 's' if nhoantimes != 1 else '', get_ordinal(rank))
         await ctx.send(embed = embed)
 
-    @commands.command(aliases = ['tnh', 'topnh'])
+    @commands.command(aliases = ['topnh', 'nhoankings', 'topcringe', 'topcrimge'])
     async def topnhoan(self, ctx, count: Optional[int] = 5):
         msg = ''
-        for i, (memb, nhoantimes) in self.get_sorted_counts(ctx.guild, count):
+        for i, (member, nhoantimes) in self.get_sorted_counts(ctx.guild, count):
             msg += TOPNHOAN_ENTRY.format(
-                i, memb.name, nhoantimes, 's' if nhoantimes != 1 else '')
+                i, member.mention, nhoantimes, 's' if nhoantimes != 1 else '')
         embed = self.init_embed(ctx.guild)
-        embed.set_author(name = TOPNHOAN_TITLE)
+
+        embed.title = TOPNHOAN_TITLE
         embed.description = msg
         await ctx.send(embed = embed)
 
 def setup(bot):
-    bot.add_cog(Nhoặn(bot))
+    bot.add_cog(Nhoan(bot))

--- a/cogs/nhoan.py
+++ b/cogs/nhoan.py
@@ -59,15 +59,18 @@ class Nhoan(commands.Cog, name='Nhoặn'):
     async def on_message(self, msg):
         ctx = await self.bot.get_context(msg)
         if ctx.command: return
+        content = msg.content
+        content = content.replace(ctx.prefix, '', 1) if ctx.prefix and content.startswith(ctx.prefix) else content
 
         for nhoan in NHOAN_SYNONYMS:
-            if nhoan in msg.content.split():
-                possible_name = msg.content.split(nhoan)[0]
+            if nhoan in content.split():
+                possible_name = content.split(nhoan)[0]
                 try:
                     member = await conv.members.FuzzyMemberConverter(matching=.6).convert(ctx, possible_name)
+                    await self.bump_nhoan_count(ctx, member)
                 except:
-                    return
-                await self.bump_nhoan_count(ctx, member)
+                    pass
+                return
     
     @commands.command(aliases = ['nhoặn', 'nh', 'cringe', 'crimge'])
     async def nhoan(self, ctx, member: Optional[conv.FuzzyMember] = None):
@@ -78,13 +81,14 @@ class Nhoan(commands.Cog, name='Nhoặn'):
         else:
             await ctx.send('No last message found. I don\'t know who to add nhoặn to!')
             return
-        if member == ctx.message.author:
-            await ctx.send('You cannot call nhoặn on yourself!')
-            return
 
         await self.bump_nhoan_count(ctx, member)
 
     async def bump_nhoan_count(self, ctx, member):
+        if member == ctx.message.author:
+            await ctx.send('You cannot call nhoặn on yourself!')
+            return
+        
         m_id = member.id
         original_count = self.allnhoan.get(m_id, 0)
         self.sync_nhoan_count(member, ctx.guild, original_count + 1)

--- a/cogs/nhoancounter.py
+++ b/cogs/nhoancounter.py
@@ -2,7 +2,7 @@ import discord
 import cogs
 import colors
 
-from typing import Optional
+from typing import Optional, Union
 from discord.ext import commands
 from .core import converter as conv
 
@@ -11,7 +11,7 @@ GUILD_NHOAN_SUM_COUNTER = 'guild_nhoan_sums'
 NHOANMSG_FIRSTTIME = '{0} just posted nhoặn for the first time!'
 NHOANMSG_UPDATE = '{0} just posted nhoặn, that\'s {1} times now!'
 NHOANMSG_QUERY_0 = '{0} has not posted nhoặn. Yet!'
-NHOANMSG_QUERY_N = '{0} has posted nhoặn {1} time{2}!'
+NHOANMSG_QUERY_N = '{0} has posted nhoặn {1} time{2}, ranking **{3}** in the server!'
 
 NHOANEMBED_AUTHOR_N = '{0}\'s nhoặn count'
 NHOANEMBED_FOOTER = 'Total server nhoặn moments counted: {0}'
@@ -38,11 +38,21 @@ class Nhoặn(commands.Cog):
 
     def init_embed(self, guild: discord.Guild):
         embed = colors.embed()
-        embed.set_footer(text=NHOANEMBED_FOOTER.format(self.allguildsnhoan.get(guild, 0)))
+        embed.set_footer(text = NHOANEMBED_FOOTER.format(self.allguildsnhoan.get(guild, 0)))
         return embed
-
+    
+    def get_sorted_counts(self, guild: discord.Guild, count = 0):
+        allnhoan = self.allnhoan
+        allnhoan_top = sorted(filter(lambda tup: tup[0] is not None, 
+            zip(map(lambda m_id: guild.get_member(int(m_id)), allnhoan), allnhoan.values())), 
+            key = lambda tup: tup[1], reverse = True)
+        if count > 0:
+            return enumerate(allnhoan_top[:count], start = 1)
+        else:
+            return enumerate(allnhoan_top, start = 1)
+        
     @commands.command(aliases = ['nhoặn', 'nh'])
-    async def nhoan(self, ctx, member:Optional[conv.FuzzyMember]=None):
+    async def nhoan(self, ctx, member: Optional[conv.FuzzyMember] = None):
         last_msgs = await ctx.channel.history(limit=2).flatten()
         msg_before_invoke = last_msgs[1] if len(last_msgs) > 1 else None
         if msg_before_invoke:
@@ -56,7 +66,7 @@ class Nhoặn(commands.Cog):
         self.sync_nhoan_count(member, ctx.guild, original_count + 1)
         
         embed = self.init_embed(ctx.guild)
-        embed.set_author(name=NHOANEMBED_AUTHOR_N.format(member.name))
+        embed.set_author(name = NHOANEMBED_AUTHOR_N.format(member.name))
         if original_count == 0:
             embed.description = NHOANMSG_FIRSTTIME.format(member.name)
         else:
@@ -65,30 +75,28 @@ class Nhoặn(commands.Cog):
         await ctx.send(embed = embed)
 
     @commands.command(aliases = ['hnh','hownh'])
-    async def hownhoan(self, ctx, member:Optional[conv.FuzzyMember]=None):
+    async def hownhoan(self, ctx, member: Optional[conv.FuzzyMember] = None):
         member = member or ctx.author
-        m_id = member.id
-        nhoantimes = self.allnhoan.get(m_id, 0)
+        for rank, (memb, nhoantimes) in self.get_sorted_counts(ctx.guild):
+            if memb == member: break
         embed = self.init_embed(ctx.guild)
-        embed.set_author(name=NHOANEMBED_AUTHOR_N.format(member.name))
+        embed.set_author(name = NHOANEMBED_AUTHOR_N.format(member.name))
         if nhoantimes == 0:
             embed.description = NHOANMSG_QUERY_0.format(member.name)
         else:
+            # get_ordinal implementation from https://stackoverflow.com/a/36977549
+            get_ordinal = lambda n: \
+                "%d%s" % (n, {1: "st", 2: "nd", 3: "rd"}.get(n if n < 20 else n % 10, "th"))
             embed.description = NHOANMSG_QUERY_N.format(member.name, \
-                str(nhoantimes), 's' if nhoantimes != 1 else '')
+                str(nhoantimes), 's' if nhoantimes != 1 else '', get_ordinal(rank))
         await ctx.send(embed = embed)
 
     @commands.command(aliases = ['tnh', 'topnh'])
-    async def topnhoan(self, ctx):
-        allnhoan = self.allnhoan
+    async def topnhoan(self, ctx, count: Optional[int] = 5):
         msg = ''
-        allnhoan_processed = filter(lambda tup: tup[0] is not None,
-            zip(map(lambda m_id: self.bot.get_user(int(m_id)), allnhoan),
-                allnhoan.values()))
-        top5 = sorted(allnhoan_processed, key = lambda tup: tup[1], reverse = True)[:5]
-        for i, (memb, nhoantimes) in enumerate(top5):
-            msg+= TOPNHOAN_ENTRY.format(
-                i+1, memb.name, nhoantimes, 's' if nhoantimes != 1 else '')
+        for i, (memb, nhoantimes) in self.get_sorted_counts(ctx.guild, count):
+            msg += TOPNHOAN_ENTRY.format(
+                i, memb.name, nhoantimes, 's' if nhoantimes != 1 else '')
         embed = self.init_embed(ctx.guild)
         embed.set_author(name = TOPNHOAN_TITLE)
         embed.description = msg

--- a/cogs/nhoancounter.py
+++ b/cogs/nhoancounter.py
@@ -1,0 +1,98 @@
+import discord
+import cogs
+import colors
+
+from typing import Optional
+from discord.ext import commands
+from .core import converter as conv
+
+NHOAN_COUNTER = 'nhoan_counter'
+GUILD_NHOAN_SUM_COUNTER = 'guild_nhoan_sums'
+NHOANMSG_FIRSTTIME = '{0} just posted nhoặn for the first time!'
+NHOANMSG_UPDATE = '{0} just posted nhoặn, that\'s {1} times now!'
+NHOANMSG_QUERY_0 = '{0} has not posted nhoặn. Yet!'
+NHOANMSG_QUERY_N = '{0} has posted nhoặn {1} time{2}!'
+
+NHOANEMBED_AUTHOR_N = '{0}\'s nhoặn count'
+NHOANEMBED_FOOTER = 'Total server nhoặn moments counted: {0}'
+
+TOPNHOAN_TITLE = 'Khúm núm before your nhoặn leaders!'
+TOPNHOAN_ENTRY = '**{0}**: {1}, with {2} nhoặn post{3}\n'
+
+class Nhoặn(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.Persist = bot.get_cog(cogs.PERSIST)
+        self.allnhoan = self.Persist.get(NHOAN_COUNTER, {})
+        self.allguildsnhoan = self.Persist.get(GUILD_NHOAN_SUM_COUNTER, {})
+
+    def sync_nhoan_count(self, member: discord.Member, guild: discord.Guild, value: int):
+        old_value = self.allnhoan.get(member.id, 0)
+        difference = value - old_value
+        
+        self.allnhoan[member.id] = value
+        self.Persist.set(NHOAN_COUNTER, self.allnhoan)
+
+        self.allguildsnhoan[guild] = self.allguildsnhoan.get(guild, 0) + difference
+        self.Persist.set(GUILD_NHOAN_SUM_COUNTER, self.allguildsnhoan)
+
+    def init_embed(self, guild: discord.Guild):
+        embed = colors.embed()
+        embed.set_footer(text=NHOANEMBED_FOOTER.format(self.allguildsnhoan.get(guild, 0)))
+        return embed
+
+    @commands.command(aliases = ['nhoặn', 'nh'])
+    async def nhoan(self, ctx, member:Optional[conv.FuzzyMember]=None):
+        last_msgs = await ctx.channel.history(limit=2).flatten()
+        msg_before_invoke = last_msgs[1] if len(last_msgs) > 1 else None
+        if msg_before_invoke:
+            member = member or msg_before_invoke.author
+        else:
+            await ctx.send('No last message found. I don\'t know who to add nhoặn to!')
+            return
+
+        m_id = member.id
+        original_count = self.allnhoan.get(m_id, 0)
+        self.sync_nhoan_count(member, ctx.guild, original_count + 1)
+        
+        embed = self.init_embed(ctx.guild)
+        embed.set_author(name=NHOANEMBED_AUTHOR_N.format(member.name))
+        if original_count == 0:
+            embed.description = NHOANMSG_FIRSTTIME.format(member.name)
+        else:
+            embed.description = NHOANMSG_UPDATE.format(member.name, \
+                str(original_count + 1))
+        await ctx.send(embed = embed)
+
+    @commands.command(aliases = ['hnh','hownh'])
+    async def hownhoan(self, ctx, member:Optional[conv.FuzzyMember]=None):
+        member = member or ctx.author
+        m_id = member.id
+        nhoantimes = self.allnhoan.get(m_id, 0)
+        embed = self.init_embed(ctx.guild)
+        embed.set_author(name=NHOANEMBED_AUTHOR_N.format(member.name))
+        if nhoantimes == 0:
+            embed.description = NHOANMSG_QUERY_0.format(member.name)
+        else:
+            embed.description = NHOANMSG_QUERY_N.format(member.name, \
+                str(nhoantimes), 's' if nhoantimes != 1 else '')
+        await ctx.send(embed = embed)
+
+    @commands.command(aliases = ['tnh', 'topnh'])
+    async def topnhoan(self, ctx):
+        allnhoan = self.allnhoan
+        msg = ''
+        allnhoan_processed = filter(lambda tup: tup[0] is not None,
+            zip(map(lambda m_id: self.bot.get_user(int(m_id)), allnhoan),
+                allnhoan.values()))
+        top5 = sorted(allnhoan_processed, key = lambda tup: tup[1], reverse = True)[:5]
+        for i, (memb, nhoantimes) in enumerate(top5):
+            msg+= TOPNHOAN_ENTRY.format(
+                i+1, memb.name, nhoantimes, 's' if nhoantimes != 1 else '')
+        embed = self.init_embed(ctx.guild)
+        embed.set_author(name = TOPNHOAN_TITLE)
+        embed.description = msg
+        await ctx.send(embed = embed)
+
+def setup(bot):
+    bot.add_cog(Nhoặn(bot))


### PR DESCRIPTION
Adds a cog that tracks and counts user nhoặn moments across all servers through `j nhoặn/nhoan/nh`. Also has commands to show a leaderboard for a server (`j topnhoan/tnh/topnh`) and to check a user's nhoặn count (`j hownhoan/hnh/hownh`).